### PR TITLE
Lookup private key for decryption in keystore

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 group = "de.tk.opensource"
-version = "1.0.3-SNAPSHOT"
+version = "1.1.0-SNAPSHOT"
 
 application {
     mainClassName = "de.tk.opensource.secon.Main"

--- a/src/main/java/de/tk/opensource/secon/Identity.java
+++ b/src/main/java/de/tk/opensource/secon/Identity.java
@@ -36,7 +36,7 @@ public interface Identity {
 
     /**
      * Sucht den privaten Schlüssel für einen Kommunikationsteilnehmer, welcher zu dem gegebenen Selektor passt.
-     * Dieser Schlüssel wird verwendet, um Nachrichten zu entschlüsseln.
+     * Dieser Schlüssel wird verwendet, um verschlüsselte Nachrichten zu entschlüsseln.
      *
      * @since 1.1.0
      */

--- a/src/main/java/de/tk/opensource/secon/Identity.java
+++ b/src/main/java/de/tk/opensource/secon/Identity.java
@@ -21,7 +21,9 @@
 package de.tk.opensource.secon;
 
 import java.security.PrivateKey;
+import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 
 /**
  * Identifiziert einen Kommunikationsteilnehmer im SECON mittels eines privaten Schlüssels und des dazugehörigen
@@ -33,9 +35,18 @@ import java.security.cert.X509Certificate;
 public interface Identity {
 
     /**
+     * Sucht den privaten Schlüssel für einen Kommunikationsteilnehmer, welcher zu dem gegebenen Selektor passt.
+     * Dieser Schlüssel wird verwendet, um Nachrichten zu entschlüsseln.
+     *
+     * @since 1.1.0
+     */
+    default Optional<PrivateKey> privateKey(X509CertSelector selector) throws Exception {
+        return selector.match(certificate()) ? Optional.of(privateKey()) : Optional.empty();
+    }
+
+    /**
      * Gibt den privaten Schlüssel für diesen Kommunikationsteilnehmer zurück.
-     * Der private Schlüssel wird verwendet um Nachrichten mit einer digitalen Signatur zu versehen und um
-     * verschlüsselte Nachrichten zu entschlüsseln.
+     * Dieser Schlüssel wird verwendet um Nachrichten mit einer digitalen Signatur zu versehen.
      *
      * @throws PrivateKeyNotFoundException falls der private Schlüssel nicht gefunden werden kann.
      * @throws Exception in allen anderen Fehlerfällen, z.B. wenn ein KeyStore nicht geladen werden kann.
@@ -44,8 +55,7 @@ public interface Identity {
 
     /**
      * Gibt das Zertifikat für diesen Kommunikationsteilnehmer zurück.
-     * Das Zertifikat wird verwendet um Nachrichten mit einer digitalen Signatur zu versehen und um verschlüsselte
-     * Nachrichten zu entschlüsseln.
+     * Dieses Zertifikat wird verwendet um Nachrichten mit einer digitalen Signatur zu versehen.
      *
      * @throws CertificateNotFoundException falls das Zertifikat nicht gefunden werden kann.
      * @throws Exception in allen anderen Fehlerfällen, z.B. wenn ein KeyStore nicht geladen werden kann.

--- a/src/main/java/de/tk/opensource/secon/KeyStoreDirectory.java
+++ b/src/main/java/de/tk/opensource/secon/KeyStoreDirectory.java
@@ -35,16 +35,16 @@ import java.util.stream.Stream;
  */
 final class KeyStoreDirectory implements Directory {
 
-    private final KeyStore keyStore;
+    private final KeyStore ks;
 
-    KeyStoreDirectory(final KeyStore keyStore) {
-        this.keyStore = keyStore;
+    KeyStoreDirectory(final KeyStore ks) {
+        this.ks = ks;
     }
 
     @Override
     public final Optional<X509Certificate> certificate(X509CertSelector selector) throws KeyStoreException {
         return Collections
-                .list(keyStore.aliases())
+                .list(ks.aliases())
                 .stream()
                 .flatMap(this::certificateStream)
                 .filter(selector::match)
@@ -61,7 +61,7 @@ final class KeyStoreDirectory implements Directory {
 
     @Override
     public final Optional<X509Certificate> certificate(final String identifier) throws KeyStoreException {
-        final Certificate cert = keyStore.getCertificate(identifier);
+        final Certificate cert = ks.getCertificate(identifier);
         return cert instanceof X509Certificate ? Optional.of((X509Certificate) cert) : Optional.empty();
     }
 }

--- a/src/main/java/de/tk/opensource/secon/SECON.java
+++ b/src/main/java/de/tk/opensource/secon/SECON.java
@@ -161,6 +161,9 @@ public final class SECON {
      * dazugehörigen Zertifikats.
      * Der Schlüssel und das Zertifikat werden aus dem gegebenen Schlüsselbund unter Verwendung des gegebenen
      * Aliasnamens mit dem gegebenen Passwort geladen.
+     * <p>
+     * Beim Entschlüsseln von Nachrichten wird der Schlüsselbund nach passenden privaten Schlüsseln durchsucht.
+     * Das gegebene Passwort muss daher zu <em>allen</em> privaten Schlüsseln im Schlüsselbund passen.
      */
     public static Identity identity(KeyStore ks, String alias, Callable<char[]> password) {
         return new KeyStoreIdentity(requireNonNull(ks), requireNonNull(alias), requireNonNull(password));


### PR DESCRIPTION
Currently, only one private key for decrypting messages can be used.
This is not enough when renewing certificates because you may still receive messages which were encrypted using the old certificate.

This pull request searches for a matching private key in the keystore instead to fix this issue.
This search is based on a certificate selector, which is already used when looking for certificates to verify signatures - see `Directory.certificate(X509CertificateSelector)`.
It introduces a new method in the `Identity` interface:

```java
default Optional<PrivateKey> privateKey(X509CertSelector selector) throws Exception {
    return selector.match(certificate()) ? Optional.of(privateKey()) : Optional.empty();
}
```

The default implementation retains the old behaviour, so custom implementations of this interface still work.
When calling `SECON.identity(KeyStore, String, Callable)` however, clients get an implementation with the new behaviour.