### PR TITLE
Validation of encryption algorithm

### DIFF
--- a/src/main/java/de/tk/opensource/secon/DefaultSubscriber.java
+++ b/src/main/java/de/tk/opensource/secon/DefaultSubscriber.java
@@ -216,7 +216,12 @@ final class DefaultSubscriber implements Subscriber {
 	}
 
     private InputStream decrypt(final InputStream in) throws Exception {
-        for (final RecipientInformation info : new CMSEnvelopedDataParser(new BufferedInputStream(in))
+        CMSEnvelopedDataParser cmsEDP = new CMSEnvelopedDataParser(new BufferedInputStream(in));
+        if(!cmsEDP.getEncryptionAlgOID().equals(CMSAlgorithm.AES256_CBC.getId())) {
+        	throw new EncryptionAlgorithmIllegalException(CMSAlgorithm.AES256_CBC.getId(), cmsEDP.getEncryptionAlgOID());
+        }
+        
+		for (final RecipientInformation info : cmsEDP
                 .getRecipientInfos()) {
             final RecipientId id = info.getRID();
             if (id instanceof KeyTransRecipientId) {

--- a/src/main/java/de/tk/opensource/secon/EncryptionAlgorithmIllegalException.java
+++ b/src/main/java/de/tk/opensource/secon/EncryptionAlgorithmIllegalException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2020 Techniker Krankenkasse
+ * Copyright © 2020 BITMARCK Service GmbH
+ *
+ * This file is part of secon-tool
+ * (see https://github.com/DieTechniker/secon-tool).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.tk.opensource.secon;
+
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+
+/**
+ * Zeigt an, dass der verwendete Verschlüsselungsalgoritmus nicht der in Anlage 16 als Standard definierte ist. 
+ * Eine Instanziierung dieser Klasse außerhalb dieses Pakets ist nicht möglich.
+ *
+ * @author  Marcus Fey
+ */
+public class EncryptionAlgorithmIllegalException extends SeconException {
+
+	private static final long serialVersionUID = 0L;
+
+	EncryptionAlgorithmIllegalException(AlgorithmIdentifier algorithmIdentifier) {
+		super("Illegal encryption algorithm: " + algorithmIdentifier.getAlgorithm());
+	}
+
+	public EncryptionAlgorithmIllegalException(String expected, String actual) {
+		super("Illegal encryption algorithm, expected: " + expected + ", actual: " + actual);
+	}
+	
+}

--- a/src/test/java/de/tk/opensource/secon/DefaultSubscriberEncBadAlgo.java
+++ b/src/test/java/de/tk/opensource/secon/DefaultSubscriberEncBadAlgo.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright © 2020 Techniker Krankenkasse
+ * Copyright © 2020 BITMARCK Service GmbH
+ *
+ * This file is part of secon-tool
+ * (see https://github.com/DieTechniker/secon-tool).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.tk.opensource.secon;
+
+import static de.tk.opensource.secon.SECON.callable;
+import static de.tk.opensource.secon.SECON.socket;
+import static java.util.Objects.requireNonNull;
+import static org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
+
+import java.io.BufferedInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.AlgorithmParameters;
+import java.security.PrivateKey;
+import java.security.cert.X509CertSelector;
+import java.security.cert.X509Certificate;
+import java.security.spec.PSSParameterSpec;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cms.CMSAlgorithm;
+import org.bouncycastle.cms.CMSEnvelopedDataParser;
+import org.bouncycastle.cms.CMSEnvelopedDataStreamGenerator;
+import org.bouncycastle.cms.CMSSignedDataParser;
+import org.bouncycastle.cms.CMSSignedDataStreamGenerator;
+import org.bouncycastle.cms.CMSTypedStream;
+import org.bouncycastle.cms.KeyTransRecipientId;
+import org.bouncycastle.cms.RecipientId;
+import org.bouncycastle.cms.RecipientInformation;
+import org.bouncycastle.cms.SignerId;
+import org.bouncycastle.cms.SignerInformation;
+import org.bouncycastle.cms.SignerInformationVerifier;
+import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
+import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder;
+import org.bouncycastle.cms.jcajce.JceCMSContentEncryptorBuilder;
+import org.bouncycastle.cms.jcajce.JceKeyTransEnvelopedRecipient;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OutputEncryptor;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+
+import global.namespace.fun.io.api.Socket;
+import global.namespace.fun.io.api.function.XFunction;
+
+/**
+ * @author  Wolfgang Schmiesing (P224488, IT.IN.FRW)
+ * @author  Christian Schlichtherle
+ */
+final class DefaultSubscriberEncBadAlgo implements Subscriber {
+
+	private volatile PrivateKey privateKey;
+	private volatile X509Certificate certificate;
+
+	private final Identity identity;
+	private final Directory[] directories;
+
+	DefaultSubscriberEncBadAlgo(final Identity identity, final Directory[] directories) {
+		this.identity = identity;
+		this.directories = directories;
+	}
+
+	private PrivateKey privateKey() throws Exception {
+		final PrivateKey k = this.privateKey;
+		return null != k ? k : (this.privateKey = identity.privateKey());
+	}
+
+	private X509Certificate certificate() throws Exception {
+		final X509Certificate c = this.certificate;
+		return null != c ? c : (this.certificate = identity.certificate());
+	}
+
+	private static X500Principal principal(final X500Name name) {
+		try {
+			return new X500Principal(name.getEncoded());
+		} catch (IOException e) {
+			throw new AssertionError(e);
+		}
+	}
+
+	private static X509CertSelector selector(final KeyTransRecipientId id) {
+		final X509CertSelector sel = new X509CertSelector();
+		Optional.ofNullable(id.getIssuer()).ifPresent(issuer -> sel.setIssuer(principal(issuer)));
+		sel.setSerialNumber(id.getSerialNumber());
+		sel.setSubjectKeyIdentifier(id.getSubjectKeyIdentifier());
+		return sel;
+	}
+
+	private static X509CertSelector selector(final SignerId id) {
+		final X509CertSelector sel = new X509CertSelector();
+		Optional.ofNullable(id.getIssuer()).ifPresent(issuer -> sel.setIssuer(principal(issuer)));
+		sel.setSerialNumber(id.getSerialNumber());
+		sel.setSubjectKeyIdentifier(id.getSubjectKeyIdentifier());
+		return sel;
+	}
+
+	private X509Certificate certificate(SignerId id) throws Exception {
+		final X509CertSelector selector = selector(id);
+		for (final Directory dir : directories) {
+			final Optional<X509Certificate> cert = dir.certificate(selector);
+			if (cert.isPresent()) {
+				return cert.get();
+			}
+		}
+		throw new CertificateNotFoundException(selector.toString());
+	}
+
+	private X509Certificate certificate(final String identifier) throws Exception {
+		for (final Directory dir : directories) {
+			final Optional<X509Certificate> cert = dir.certificate(identifier);
+			if (cert.isPresent()) {
+				return cert.get();
+			}
+		}
+		throw new CertificateNotFoundException(identifier);
+	}
+
+	private OutputStream sign(final OutputStream out) throws Exception {
+		final PrivateKey key = privateKey(); // may throw `PrivateKeyNotFoundException`
+		final X509Certificate cert = certificate(); // may throw `CertificateNotFoundException`
+		final ASN1ObjectIdentifier sigAlgOID = new ASN1ObjectIdentifier(cert.getSigAlgOID());
+		final ContentSigner signer;
+		if (PKCSObjectIdentifiers.id_RSASSA_PSS.equals(sigAlgOID)) {
+			AlgorithmParameters parameters = AlgorithmParameters.getInstance(cert.getSigAlgName());
+			parameters.init(cert.getSigAlgParams());
+			signer =
+				new JcaContentSignerBuilder(cert.getSigAlgName(), parameters.getParameterSpec(PSSParameterSpec.class))
+					.setProvider(PROVIDER_NAME)
+					.build(key);
+
+		} else {
+			signer = new JcaContentSignerBuilder(cert.getSigAlgName())
+					.setProvider(PROVIDER_NAME)
+					.build(key);
+		}
+		final CMSSignedDataStreamGenerator gen = new CMSSignedDataStreamGenerator();
+		gen.addSignerInfoGenerator(
+			new JcaSignerInfoGeneratorBuilder(
+				new JcaDigestCalculatorProviderBuilder()
+					.setProvider(PROVIDER_NAME)
+					.build()
+			).build(signer, cert)
+		);
+		return gen.open(out, true);
+	}
+
+	private final XFunction<OutputStream, OutputStream> sign = Streams.fixOutputstreamClose(this::sign);
+
+	private InputStream verify(final InputStream in, final Verifier verifier) throws Exception {
+		final CMSSignedDataParser parser =
+			new CMSSignedDataParser(
+				new JcaDigestCalculatorProviderBuilder().setProvider(PROVIDER_NAME).build(),
+				new BufferedInputStream(in)
+			);
+		final CMSTypedStream signedContent = parser.getSignedContent();
+		return
+			new FilterInputStream(signedContent.getContentStream()) {
+
+				@Override
+				public void close() throws IOException {
+					SideEffect.runAll(signedContent::drain, this::verifyIo);
+				}
+
+				private void verifyIo() throws IOException {
+					try {
+						verify();
+					} catch (IOException | RuntimeException e) {
+						throw e;
+					} catch (Exception e) {
+						throw new IOException(e);
+					}
+				}
+
+				private void verify() throws Exception {
+					for (final SignerInformation info : parser.getSignerInfos()) {
+						final X509Certificate cert = certificate(info.getSID());
+						final SignerInformationVerifier ver =
+							new JcaSimpleSignerInfoVerifierBuilder()
+								.setProvider(PROVIDER_NAME)
+								.build(cert);
+						if (!info.verify(ver)) {
+							throw new InvalidSignatureException();
+						}
+						verifier.verify(cert);
+					}
+				}
+			};
+	}
+
+	private XFunction<InputStream, InputStream> verify(Verifier v) {
+		return Streams.fixInputstreamClose(in -> verify(in, v));
+	}
+
+	private OutputStream encrypt(final OutputStream out, final Callable<X509Certificate>[] recipients)
+		throws Exception
+	{
+		final CMSEnvelopedDataStreamGenerator gen = new CMSEnvelopedDataStreamGenerator();
+		Arrays.stream(recipients).map(RecipientInfoGeneratorFactory::create).forEach(gen::addRecipientInfoGenerator);
+		final OutputEncryptor encryptor =
+			new JceCMSContentEncryptorBuilder(CMSAlgorithm.DES_CBC)
+				.setProvider(PROVIDER_NAME)
+				.build();
+		return gen.open(out, encryptor);
+	}
+
+	private XFunction<OutputStream, OutputStream> encrypt(Callable<X509Certificate>[] recipients) {
+		return Streams.fixOutputstreamClose(out -> encrypt(out, recipients));
+	}
+
+    private InputStream decrypt(final InputStream in) throws Exception {
+        for (final RecipientInformation info : new CMSEnvelopedDataParser(new BufferedInputStream(in))
+                .getRecipientInfos()) {
+            final RecipientId id = info.getRID();
+            if (id instanceof KeyTransRecipientId) {
+                final X509CertSelector selector = selector((KeyTransRecipientId) id);
+                final Optional<PrivateKey> optKey = identity.privateKey(selector);
+                if (optKey.isPresent()) {
+                    return info
+                            .getContentStream(new JceKeyTransEnvelopedRecipient(optKey.get())
+									.setProvider(PROVIDER_NAME))
+                            .getContentStream();
+                }
+            }
+        }
+        throw new CertificateMismatchException();
+    }
+
+	private final XFunction<InputStream, InputStream> decrypt = Streams.fixInputstreamClose(this::decrypt);
+
+	private Socket<OutputStream> signAndEncryptTo(Socket<OutputStream> output, Callable<X509Certificate>[] recipients) {
+		return output.map(sign.compose(encrypt(recipients)));
+	}
+
+	@Override
+	public SeconCallable<OutputStream> signAndEncryptTo(
+		final Callable<OutputStream> output,
+		final X509Certificate		 recipient,
+		final X509Certificate...     others
+	) {
+		@SuppressWarnings("unchecked")
+		final Callable<X509Certificate>[] recipients = new Callable[others.length + 1];
+		requireNonNull(recipient);
+		recipients[0] = () -> recipient;
+		for (int i = 0; i < others.length;) {
+			final X509Certificate other = requireNonNull(others[i]);
+			recipients[++i] = () -> other;
+		}
+		return callable(signAndEncryptTo(socket(output), recipients));
+	}
+
+	@Override
+	public SeconCallable<OutputStream> signAndEncryptTo(
+		final Callable<OutputStream> output,
+		final String				 recipientId,
+		final String... 			 otherIds
+	) {
+		@SuppressWarnings("unchecked")
+		final Callable<X509Certificate>[] recipients = new Callable[otherIds.length + 1];
+		requireNonNull(recipientId);
+		recipients[0] = () -> certificate(recipientId);
+		for (int i = 0; i < otherIds.length;) {
+			final String other = requireNonNull(otherIds[i]);
+			recipients[++i] = () -> certificate(other);
+		}
+		return callable(signAndEncryptTo(socket(output), recipients));
+	}
+
+	private Socket<InputStream> decryptAndVerifyFrom(Socket<InputStream> input, Verifier v) {
+		return input.map(verify(v).compose(decrypt));
+	}
+
+	@Override
+	public SeconCallable<InputStream> decryptAndVerifyFrom(Callable<InputStream> input, Verifier v) {
+		return callable(decryptAndVerifyFrom(socket(input), v));
+	}
+}

--- a/src/test/java/de/tk/opensource/secon/KksAlgorithmsBadAlgo.java
+++ b/src/test/java/de/tk/opensource/secon/KksAlgorithmsBadAlgo.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2020 Techniker Krankenkasse
+ * Copyright © 2020 BITMARCK Service GmbH
+ *
+ * This file is part of secon-tool
+ * (see https://github.com/DieTechniker/secon-tool).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.tk.opensource.secon;
+
+import javax.crypto.spec.*;
+
+import org.bouncycastle.asn1.*;
+import org.bouncycastle.asn1.nist.*;
+import org.bouncycastle.asn1.pkcs.*;
+import org.bouncycastle.asn1.x509.*;
+
+/**
+ * @author  Wolfgang Schmiesing (P224488, IT.IN.FRW)
+ * @author  Christian Schlichtherle
+ */
+final class KksAlgorithmsBadAlgo {
+
+	private static final AlgorithmIdentifier OAEP_HASH_ALGORITHM =
+		new AlgorithmIdentifier(NISTObjectIdentifiers.id_sha256, DERNull.INSTANCE);
+
+	private static final AlgorithmIdentifier OAEP_MASK_GEN_FUNCTION =
+		new AlgorithmIdentifier(PKCSObjectIdentifiers.id_mgf1, OAEP_HASH_ALGORITHM);
+
+	private static final AlgorithmIdentifier OAEP_P_SOURCE =
+		new AlgorithmIdentifier(
+			PKCSObjectIdentifiers.id_pSpecified,
+			new DEROctetString(PSource.PSpecified.DEFAULT.getValue())
+		);
+
+	static final AlgorithmIdentifier ENCRYPTION_ALGORITHM_RSAES_OAEP =
+		new AlgorithmIdentifier(
+			PKCSObjectIdentifiers.id_RSAES_OAEP,
+			new RSAESOAEPparams(OAEP_HASH_ALGORITHM, OAEP_MASK_GEN_FUNCTION, OAEP_P_SOURCE)
+		);
+	
+	static final AlgorithmIdentifier ENCRYPTION_ALGORITHM_RSASSA_PSS =
+		new AlgorithmIdentifier(
+			PKCSObjectIdentifiers.id_RSASSA_PSS,
+			new RSASSAPSSparams(OAEP_HASH_ALGORITHM, OAEP_MASK_GEN_FUNCTION, new  ASN1Integer(10), new ASN1Integer(20))
+		);		
+}

--- a/src/test/java/de/tk/opensource/secon/SECONEncBadAlgo.java
+++ b/src/test/java/de/tk/opensource/secon/SECONEncBadAlgo.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright © 2020 Techniker Krankenkasse
+ * Copyright © 2020 BITMARCK Service GmbH
+ *
+ * This file is part of secon-tool
+ * (see https://github.com/DieTechniker/secon-tool).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.tk.opensource.secon;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.security.KeyStore;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.concurrent.Callable;
+
+import javax.naming.Context;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import global.namespace.fun.io.api.Socket;
+import global.namespace.fun.io.bios.BIOS;
+
+/**
+ * Stellt CMS-Dienste (Cryptographic Message Syntax) für das Krankenkassenkommunikationssystem (SECON) bereit.
+ * Diese Fassade ist der Haupteinstiegspunkt von diesem API.
+ * <p>
+ * Im folgenden Beispiel signiert Alice zunächst eine Nachricht mit ihrem privaten Schlüssel und verschlüsselt diese
+ * dann mit dem öffentlichen Schlüssel aus dem Zertifikat für Bob.
+ * Bob wiederum entschlüsselt die Nachricht mit seinem privaten Schlüssel und überprüft die Signatur von Alice mit dem
+ * öffentlichen Schlüssel aus dem Zertifikat für Alice.
+ * Die privaten Schlüsselpaare werden der Einfachheit halber in einem Schlüsselbund im PKCS12-Format gespeichert.
+ * Für dieses Beispiel benötigt der Schlüsselbund daher lediglich zwei Einträge mit den privaten Schlüsselpaaren für
+ * Alice und Bob.
+ * <pre>{@code
+ * import java.io.*;
+ * import java.security.*;
+ * import java.util.concurrent.Callable;
+ *
+ * import de.tk.opensource.secon.*;
+ *
+ * import static de.tk.opensource.secon.SECON.*;
+ *
+ * class Scratch {
+ *
+ *     public static void main(String... unused) throws SeconException {
+ *         // Wir benötigen einen Schlüsselbund mit jeweils einem eigenen privaten Schlüsselbund-Eintrag für Alice und
+ *         // Bob:
+ *         KeyStore keyStore = keyStore(() -> new FileInputStream("keystore.p12"), "secret"::toCharArray);
+ *
+ *         // Als nächstes erzeugen beide Kommunikationsteilnehmer jeweils eine eigene Identität:
+ *         Identity aliceId = identity(keyStore, "Alice's alias", "Alice's password"::toCharArray);
+ *         Identity bobId = identity(keyStore, "Bob's alias", "Bob's password"::toCharArray);
+ *
+ *         // Außerdem verwenden beide Kommunikationsteilnehmer denselben Schlüsselbund als Verzeichnisdienst für
+ *         // Zertifikate:
+ *         Directory keyStoreDir = directory(keyStore);
+ *
+ *         // Beide Kommunikationsteilnehmer benötigen jeweils einen eigenen Kontext für den Versand und Empfang von
+ *         // Nachrichten:
+ *         Subscriber aliceSub = subscriber(aliceId, keyStoreDir);
+ *         Subscriber bobSub = subscriber(bobId, keyStoreDir);
+ *
+ *         // Nun kann Alice eine Nachricht digital signieren und für Bob verschlüsseln indem sie erneuerbare Ein-
+ *         // und Ausgabeströme entsprechend ihrer Verwendung dekoriert und dann die Daten mit Hilfe dieser erneuerbaren
+ *         // Ströme einfach kopiert.
+ *         // Der Einfachheit halber verwenden wir in diesem Beispiel Dateien, wobei anfangs lediglich die Datei
+ *         // `message.txt` existieren muss - alle folgenden Dateien werden ggf. überschrieben.
+ *         // Da Alice den Schlüsselbund gleichzeitig als Zertifikats-Verzeichnisdienst verwendet, kann sie Bob einfach
+ *         // durch seinen Aliasnamen identifizieren:
+ *         Callable<InputStream> plainIn = () -> new FileInputStream("message.txt");
+ *         Callable<OutputStream> cipherOut = aliceSub.signAndEncryptTo(() -> new FileOutputStream("message.cms"),
+ *                 "Bob's alias");
+ *         copy(plainIn, cipherOut);
+ *
+ *         // ... und Bob kann die Nachricht entschlüsseln und die digitale Signatur von Alice überprüfen indem er
+ *         // ebenfalls erneuerbare Ein- und Ausgabeströme quasi umgekehrt dekoriert und dann wiederum die Daten mit
+ *         // Hilfe dieser erneuerbaren Ströme einfach kopiert.
+ *         // Wenn die Überprüfung der digitalen Signatur fehlschlägt, dann wird die `close()`-Methode des erneuerbaren
+ *         // Ausgabestroms `plainOut` eine `InvalidSignatureException` auslösen - dies passiert verdeckt innerhalb
+ *         // des `copy(...)`-Aufrufs:
+ *         Callable<InputStream> cipherIn = bobSub.decryptAndVerifyFrom(() -> new FileInputStream("message.cms"));
+ *         Callable<OutputStream> plainOut = () -> new FileOutputStream("clonedmessage.txt");
+ *         copy(cipherIn, plainOut);
+ *     }
+ * }
+ * }</pre>
+ *
+ * @author Christian Schlichtherle
+ * @see <a href="https://www.gkv-datenaustausch.de/media/dokumente/standards_und_normen/technische_spezifikationen/Anlage_16_-_Security-Schnittstelle.pdf">Anlage 16 - Security Schnittstelle (SECON) (PDF, 1.2 MB)</a>
+ * @see <a href="https://www.gkv-datenaustausch.de/media/dokumente/standards_und_normen/technische_spezifikationen/Best_Practice_Security.pdf">Best Practice zur Security-Schnittstelle (PDF, 499 KB)</a>
+ */
+public final class SECONEncBadAlgo {
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+        Security.setProperty("crypto.policy", "unlimited");
+    }
+
+    private SECONEncBadAlgo() {
+    }
+
+    /**
+     * Erzeugt einen initialisierten Schlüsselbund mit dem Inhalt aus dem gegebenen erneuerbaren Eingabestrom unter
+     * Verwendung des gegebenen Passworts.
+     * Der Inhalt des Eingabestroms muß dem PKCS12-Format entsprechen.
+     */
+    public static KeyStore keyStore(Callable<InputStream> input, Callable<char[]> password) throws SeconException {
+        return keyStore(input, password, "PKCS12");
+    }
+
+    /**
+     * Erzeugt einen initialisierten Schlüsselbund mit dem Inhalt aus dem gegebenen erneuerbaren Eingabestrom unter
+     * Verwendung des gegebenen Passworts.
+     * Der Inhalt des Eingabestroms muß dem gegebenen Typ des Schlüsselbunds entsprechen.
+     */
+    public static KeyStore keyStore(
+            Callable<InputStream> input,
+            Callable<char[]> password,
+            String type
+    ) throws SeconException {
+        return call(() -> keyStore(socket(input), password, type));
+    }
+
+    private static KeyStore keyStore(
+            final Socket<InputStream> input,
+            final Callable<char[]> password,
+            final String type
+    ) throws Exception {
+        final KeyStore ks = KeyStore.getInstance(type);
+        final char[] pwChars = password.call();
+        try {
+            input.accept(in -> ks.load(in, pwChars));
+        } finally {
+            Arrays.fill(pwChars, (char) 0);
+        }
+        return ks;
+    }
+
+    /**
+     * Erzeugt eine Identität für einen Kommunikationsteilnehmer im SECON mittels eines privaten Schlüssels und des
+     * dazugehörigen Zertifikats.
+     * Der Schlüssel und das Zertifikat werden aus dem gegebenen Schlüsselbund unter Verwendung des gegebenen
+     * Aliasnamens mit dem gegebenen Passwort geladen.
+     * <p>
+     * Beim Entschlüsseln von Nachrichten wird der Schlüsselbund nach passenden privaten Schlüsseln durchsucht.
+     * Das gegebene Passwort muss daher zu <em>allen</em> privaten Schlüsseln im Schlüsselbund passen.
+     */
+    public static Identity identity(KeyStore ks, String alias, Callable<char[]> password) {
+        return new KeyStoreIdentity(requireNonNull(ks), requireNonNull(alias), requireNonNull(password));
+    }
+
+    /**
+     * Erzeugt einen Verzeichnisdienst für Zertifikate von Kommunikationsteilnehmern im SECON.
+     * Die Zertifikate werden aus dem gegebenen Schlüsselbund geladen.
+     */
+    public static Directory directory(KeyStore ks) {
+        return new KeyStoreDirectory(requireNonNull(ks));
+    }
+
+    /**
+     * Erzeugt einen Verzeichnisdienst für Zertifikate von Kommunikationsteilnehmern im SECON.
+     * Die Zertifikate werden aus einem LDAP-Server unter Verwendung des gegebenen Verbindungspools geladen.
+     * <p>
+     * Das Schema des Directory Information Tree muss Kapitel 4.6.2 "LDAP-Verzeichnis" der
+     * <a href="https://www.gkv-datenaustausch.de/media/dokumente/standards_und_normen/technische_spezifikationen/Anlage_16_-_Security-Schnittstelle.pdf">Security-Schnittstelle (SECON) - Anlage 16</a>
+     * entsprechen.
+     *
+     * @param pool Ein Pool von Verbindungen zum LDAP-Server.
+     */
+    public static Directory directory(Callable<DirContext> pool) {
+        return new LdapDirectory(requireNonNull(pool)::call);
+    }
+
+    /**
+     * Erzeugt einen LDAP-Verbindungspool für den gegebenen URL.
+     * Die Zertifikate werden aus einem LDAP-Server unter Verwendung des gegebenen URLs geladen.
+     * Alle Verbindungen werden in einem Pool verwaltet.
+     * Der LDAP-Server muss anonymen Lesezugriff erlauben und das Schema des Directory Information Tree muss Kapitel
+     * 4.6.2 "LDAP-Verzeichnis" der
+     * <a href="https://www.gkv-datenaustausch.de/media/dokumente/standards_und_normen/technische_spezifikationen/Anlage_16_-_Security-Schnittstelle.pdf">Security-Schnittstelle (SECON) - Anlage 16</a>
+     * entsprechen.
+     *
+     * @param url Ein URL mit dem Schema {@code ldap}.
+     */
+    public static Directory directory(final URI url) {
+        if (url.getScheme().equalsIgnoreCase("ldap")) {
+            final Hashtable<String, String> e = ldapEnvironment(url);
+            return directory(() -> new InitialDirContext(e));
+        } else {
+            throw new UnsupportedOperationException(url.getScheme());
+        }
+    }
+
+    private static Hashtable<String, String> ldapEnvironment(final URI url) {
+        final Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, url.toString());
+        env.put("com.sun.jndi.ldap.connect.pool", "true");
+        return env;
+    }
+
+    /**
+     * Erzeugt einen Kommunikationsteilnehmer im SECON unter Verwendung der gegebenen Identität und der geordneten Liste
+     * von Verzeichnisdiensten für Zertifikate.
+     */
+    public static Subscriber subscriber(
+            final Identity identity,
+            final Directory directory,
+            final Directory... others) {
+        final Directory[] directories = new Directory[others.length + 1];
+        directories[0] = requireNonNull(directory);
+        for (int i = 0; i < others.length; ) {
+            final Directory other = others[i];
+            directories[++i] = requireNonNull(other);
+        }
+        return new DefaultSubscriberEncBadAlgo(requireNonNull(identity), directories);
+    }
+
+    /**
+     * Kopiert einen erneuerbaren Eingabestrom zu einem erneuerbaren Ausgabestrom.
+     * Um eine optimale Leistung zu erzielen, wird der Eingabestrom nebenläufig im Hintergrund gelesen.
+     */
+    public static void copy(Callable<InputStream> input, Callable<OutputStream> output) throws SeconException {
+        call(() -> {
+            BIOS.copy(socket(input), socket(output));
+            return null;
+        });
+    }
+
+    static <T extends AutoCloseable> Socket<T> socket(Callable<T> c) {
+        return c::call;
+    }
+
+    private static <V> V call(Callable<V> c) throws SeconException {
+        return callable(c).call();
+    }
+
+    private static <V> SeconCallable<V> callable(Callable<V> c) {
+        return () -> {
+            try {
+                return c.call();
+            } catch (final Exception e) {
+                rethrow(e);
+                if (e instanceof RuntimeException) {
+                    throw (RuntimeException) e;
+                } else {
+                    throw new SeconException(e);
+                }
+            }
+        };
+    }
+
+    private static void rethrow(Throwable t) throws SeconException {
+        for (; null != t; t = t.getCause()) {
+            if (t instanceof SeconException) {
+                throw (SeconException) t;
+            }
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    static <V extends AutoCloseable> SeconCallable<V> callable(Socket<V> s) {
+        return callable((Callable<V>) s::get);
+    }
+}


### PR DESCRIPTION
Anlage 16 sets AES256_CBC as "standard". Although it's unclear to me whether this should regarded as the only legal algorithm. In any case the receiver should somehow verify that the message was encrypted using a secure algorithm and not ... "advanced ROT13".

Possible fix for #41 

Sorry for the insane amount of test code, you might want to refactor it (I needed to create a "SECON tool" with deprecated encryption algorithms, the main classes being final prohibited sub-classes - there might be way better solutions for testing)