### PR TITLE
Update plugin versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,9 @@ plugins {
     `java-library`
     `maven-publish`
     signing
-    id("com.github.johnrengelman.shadow") version "6.0.0"
-    id("biz.aQute.bnd.builder") version "5.1.2"
-    id("net.minecrell.licenser") version "0.4.1"
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("biz.aQute.bnd.builder") version "6.1.0"
+    id("org.cadixdev.licenser") version "0.6.1"
 }
 
 repositories {
@@ -93,9 +93,9 @@ tasks.register<Test>("testLdap") {
 }
 
 license {
-	header = project.file("LICENSE.header")
+	header(project.file("LICENSE.header"))
 	include("**/*.java,**/*.kts")
-	newLine = false
+	newLine.set(false)
 }
 
 publishing {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update to Gradle 7.x
Update of Gradle shadow plugin to 7.1.2 (fixes Log4j dependency)